### PR TITLE
@/trpc/server を使ってapi側の2重コールをなくす

### DIFF
--- a/src/app/components/user.tsx
+++ b/src/app/components/user.tsx
@@ -1,13 +1,18 @@
 'use client'
 
-import { useState } from 'react'
+import { type FC, useState } from 'react'
 
 import { api } from '@/trpc/react'
 import styles from '../index.module.css'
 import { errorHandler } from '@/lib/error/errorHandler'
-export function LatestUser() {
+import type { User } from '@prisma/client'
+
+type Props = {
+  latestUser: User
+}
+
+export const LatestUser: FC<Props> = ({ latestUser }) => {
   // const { data: latestUser } = api.user.first.useQuery()
-  const [latestUser] = api.user.first.useSuspenseQuery()
   const utils = api.useUtils()
   const [name, setName] = useState('')
   const [email, setEmail] = useState('')

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,14 @@
 import Link from 'next/link'
 
 import { LatestUser } from '@/app/components/user'
-import { api } from '@/trpc/server'
 import styles from './index.module.css'
+import { api } from '@/trpc/server'
 export const metadata = {
   title: 'next template',
 }
 
 export default async function Home() {
-  const hello = await api.user.hello({ text: 'from tRPC' })
+  const latestUser = await api.user.first()
 
   return (
     <main className={styles.main}>
@@ -32,10 +32,10 @@ export default async function Home() {
           </Link>
         </div>
         <div className={styles.showcaseContainer}>
-          <p className={styles.showcaseText}>{hello ? hello.greeting : 'Loading tRPC query...'}</p>
+          {/* <p className={styles.showcaseText}>{hello ? hello.greeting : 'Loading tRPC query...'}</p> */}
         </div>
         <Link href={'/sample'}>to sample page</Link>
-        <LatestUser />
+        {latestUser && <LatestUser {...{ latestUser }} />}
       </div>
     </main>
   )


### PR DESCRIPTION
## 実装内容
表題の通り

## 備考
useSuspenseQueryでサーバーサイド側だけで呼ばれることを期待しているが、クライアントサイドと、サーバーサイド側の2回呼ばれている。
@/trpc/serverのapiを使って、サーバーサイド側で一度だけ呼ばれるように修正


### 画像/動画等


![スクリーンショット 2024-07-28 15 14 05](https://github.com/user-attachments/assets/6b5651df-e538-4b5f-a4ae-aeea68bf76d8)
